### PR TITLE
Initialize Next.js skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals", "prettier"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run test
+      - run: npx prisma migrate deploy
+      - run: npx vercel --prod --token ${{ secrets.VERCEL_TOKEN }}

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"; exit 0
+  fi
+  if [ -f ~/.huskyrc ]; then
+    debug "~/.huskyrc found, sourcing..."; . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exit $?
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# vibes-library
+# VIBES Library
+
+Dieses Repository enthält den Grundaufbau der VIBES Community Plattform. Es nutzt **Next.js 15**, **React 19** und **TypeScript 5**.
+
+## Entwicklung
+
+```bash
+npm install
+npm run dev
+```
+
+## Tests
+
+```bash
+npm run test
+```
+
+## Deployment
+
+Der Deploy Workflow wird über GitHub Actions ausgelöst und befindet sich unter `.github/workflows/deploy.yml`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next export"
+    "export": "next export",
+    "test": "vitest",
+    "format": "prettier --check .",
+    "prepare": "husky install"
   },
   "dependencies": {
     "next": "15.3.3",
@@ -21,6 +24,22 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@types/jest": "^29.5.0",
+    "husky": "^8.0.0",
+    "lint-staged": "^15.2.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,css,md}": [
+      "prettier --write"
+    ]
   }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+npm ci
+npm run build
+npx prisma migrate deploy
+npx vercel --prod --token "$VERCEL_TOKEN"

--- a/src/__tests__/home.test.tsx
+++ b/src/__tests__/home.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import HomePage from '../app/page';
+import { describe, it, expect } from 'vitest';
+
+describe('HomePage', () => {
+  it('renders headline', () => {
+    render(<HomePage />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Willkommen bei VIBES',
+    );
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="de">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold">Willkommen bei VIBES</h1>
+      <p className="mt-4">Die Community-Plattform für Open Source Innovation.</p>
+    </main>
+  );
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- add Next.js 15 skeleton with TypeScript
- configure ESLint, Prettier and Vitest
- add basic home page and layout
- add deploy workflow and sample deploy script

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f414c0fb4833287983464dd882cc6