### PR TITLE
Update React to v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # vibes-library
+
+This project uses **React 18**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.3.3",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
         "tailwindcss": "^4",
         "typescript": "^5"
       }

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
   },
   "dependencies": {
     "next": "15.3.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
     "tailwindcss": "^4",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary
- update `react` and `react-dom` to v18
- downgrade matching `@types/*` packages
- mention React 18 in the README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f43fca1ac8332aeffc4c294091dd3